### PR TITLE
Replace useEffect with direct browser detection in ReactQueryProvider

### DIFF
--- a/services/react-query-provider.tsx
+++ b/services/react-query-provider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PropsWithChildren, useEffect, useState } from "react";
+import { PropsWithChildren, useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
 import { createSyncStoragePersister } from "@tanstack/query-sync-storage-persister";
@@ -18,12 +18,9 @@ export default function ReactQueryProvider({ children }: PropsWithChildren) {
       }),
   );
 
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => {
-    setMounted(true);
-  }, []);
+  const isBrowser = typeof window !== "undefined";
 
-  if (!mounted) {
+  if (!isBrowser) {
     return (
       <QueryClientProvider client={client}>{children}</QueryClientProvider>
     );


### PR DESCRIPTION
### TL;DR

Improved server-side rendering compatibility in the React Query Provider by replacing the mounted state with a direct browser detection approach.

### What changed?

- Removed the `useEffect` hook and `mounted` state that was previously used to detect client-side rendering
- Replaced it with a direct browser environment check using `typeof window !== "undefined"`
- Simplified the conditional rendering logic by using the `isBrowser` variable instead of the `mounted` state
- Removed the unused `useEffect` import

### How to test?

1. Verify that the application loads correctly on both server and client sides
2. Check that React Query functionality works as expected after initial load
3. Confirm there are no hydration errors in the console related to React Query
4. Test that data persistence works properly between page refreshes

### Why make this change?

The previous implementation used a `useEffect` hook to determine if the component was mounted, which is a common pattern but can lead to unnecessary re-renders. The new approach directly checks if the code is running in a browser environment, which is more efficient and avoids the extra state update. This change improves the server-side rendering compatibility of the React Query Provider while maintaining the same functionality.