### PR TITLE
github external

### DIFF
--- a/app/_content/contact/content.ts
+++ b/app/_content/contact/content.ts
@@ -1,33 +1,34 @@
-import { AtSign, Github, Linkedin, Mail, Twitter } from 'lucide-react';
+import { AtSign, Github, Linkedin, Mail, Twitter } from "lucide-react";
 
-import { IContentGroup } from '@/app/[topic]/_constants/content-types';
+import { IContentGroup } from "@/app/[topic]/_constants/content-types";
 
 const CONTENT: IContentGroup = {
-  title: 'Contact',
+  title: "Contact",
   Icon: AtSign,
-  href: '/contact',
+  href: "/contact",
   items: [
     {
-      title: 'Email',
-      href: 'mailto:charlie@charliemeyer.xyz',
+      title: "Email",
+      href: "mailto:charlie@charliemeyer.xyz",
       Icon: Mail,
     },
     {
-      title: 'LinkedIn',
-      href: 'https://www.linkedin.com/in/charlie-meyer-loves-you/',
+      title: "LinkedIn",
+      href: "https://www.linkedin.com/in/charlie-meyer-loves-you/",
       Icon: Linkedin,
       external: true,
     },
     {
-      title: 'Twitter',
-      href: 'https://x.com/charlie_meyer_',
+      title: "Twitter",
+      href: "https://x.com/charlie_meyer_",
       Icon: Twitter,
       external: true,
     },
     {
-      title: 'GitHub',
-      href: 'https://github.com/charliemeyer2000',
+      title: "GitHub",
+      href: "https://github.com/charliemeyer2000",
       Icon: Github,
+      external: true,
     },
   ],
 };


### PR DESCRIPTION
### TL;DR

Added `external: true` property to the GitHub contact link and standardized quote style.

### What changed?

- Added the `external: true` property to the GitHub contact link in the contact content configuration
- Changed all single quotes to double quotes throughout the file for consistency

### How to test?

1. Navigate to the contact page
2. Click on the GitHub link
3. Verify that the link opens in a new tab (due to the `external: true` property)

### Why make this change?

This change ensures consistent behavior across all external links in the contact section. Previously, the GitHub link was missing the `external: true` property, which meant it wouldn't open in a new tab like the other external links. The quote style was also standardized to double quotes for better code consistency.