### PR TITLE
cleanup index page + uvacompute

### DIFF
--- a/app/_content/posts/content.ts
+++ b/app/_content/posts/content.ts
@@ -1,20 +1,25 @@
-import { Book, FileText, ShieldAlert } from 'lucide-react';
+import { Book, FileText, ShieldAlert, CpuIcon } from "lucide-react";
 
-import { IContentGroup } from '@/app/[topic]/_constants/content-types';
+import { IContentGroup } from "@/app/[topic]/_constants/content-types";
 
 const CONTENT: IContentGroup = {
-  title: 'Posts',
+  title: "Posts",
   Icon: Book,
-  href: '/posts',
+  href: "/posts",
   items: [
     {
-      title: 'Security in the Vibe-Coding Age — Hacking Series.so',
-      href: '/posts/security-in-the-vibe-coding-age-hacking-series-so',
+      title: "Security in the Vibe-Coding Age — Hacking Series.so",
+      href: "/posts/security-in-the-vibe-coding-age-hacking-series-so",
       Icon: ShieldAlert,
     },
     {
-      title: 'README.md',
-      href: '/posts/readme-md',
+      title: "uvacompute",
+      href: "/posts/uvacompute",
+      Icon: CpuIcon,
+    },
+    {
+      title: "README.md",
+      href: "/posts/readme-md",
       Icon: FileText,
     },
   ],

--- a/app/_content/posts/readme-md.md
+++ b/app/_content/posts/readme-md.md
@@ -1,31 +1,45 @@
 ---
-title: 'README.md'
+title: "README.md"
 visibility: public
 ---
 
-Hey, I'm Charlie Meyer.
+hey, I'm charlie meyer.
 
 ---
 
-## Currently
+## currently
 
-I'm a third year @ UVA studying Computer Science and Entrepreneurship. I'm a 2025 [Neo Scholar](https://neo.com/scholars), Model UN-er, dedicated weightlifter, and decent snowboarder. Previously, I've worked at [Principal Financial](https://www.principal.com/), [Scenthound](https://www.scenthound.com/), and [Vercel](https://vercel.com/). I also hack on side projects like [Hufflo](https://hufflo.com/) and [simpletext](https://simpletext.dev/).
+I'm a fourth year @ UVA studying computer science and entrepreneurship. I'm a 2025 [Neo Scholar](https://neo.com/scholars), Model UN-er, dedicated weightlifter, and (decent) snowboarder. Previously, I've worked at [Principal Financial](https://www.principal.com/), [Scenthound](https://www.scenthound.com/), and [Vercel](https://vercel.com/).
 
 I work on inference research with [Zhepei Wei](https://weizhepei.com/) and independently explore AI for math research. How can we get LLMs to reason in formal math (Lean)?
 
 ---
 
-## Future
+## built
+
+- [simpletext](https://simpletext.dev): stupidly simple sms provider
+- [hufflo](https://hufflo.com): ecommerce marketing on autopilot
+
+## in progress
+
+- [uvacompute](https://uvacompute.com): rent compute from my personal workstation at $0.50 per 5090-hour
+
+## todo
+
+- self driving couch
+- my own os
+
+---
+
+## future
 
 The intersection of what I'm good at, what I care about, and what's important in the world is AGI and AI safety. So I'm working on that, and
 its subproblems. That currently being inference research, automated theorem proving, and some safety work.
 
 I'm also deeply interested in the infrastructure behind AI research. Why is it so hard to run experiments at scale, multi-node, multi-gpu? Training and serving models should be as easy as developing and deploying web apps.
 
-Aside from running the SF marathon again, I need to run the NYC Marathon. I'd want to get to the [Copenhagen Open](https://www.cphopen.com/) or [Dime](https://dimemtl.com/blogs/videos).
-
 ---
 
-## Talk to me
+## talk to me
 
-I'm open to work. If my interests align with what you're doing or are just someone who's incredibly passionate about something, I'd love to chat.
+I'm open to work at somewhere dope. If my interests align with what you're doing or are just someone who's incredibly passionate about something, I'd love to chat.

--- a/app/_content/posts/uvacompute.md
+++ b/app/_content/posts/uvacompute.md
@@ -1,0 +1,8 @@
+---
+title: uvacompute
+visibility: private
+---
+
+# personal work log
+
+8/10 - scoping out computer specs

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,11 +1,12 @@
-import Link from 'next/link';
+import Link from "next/link";
+import { Title } from "@/components/intuitive-ui/(native)/(typography)/title";
 
 const NotFound = () => {
   return (
     <div className="flex h-dvh flex-col items-center justify-center gap-2">
-      <p className="text-muted-foreground text-lg">
-        sorry, this doesn&apos;t exist. let&apos;s go home.
-      </p>
+      <Title size="md">
+        sorry, this page doesn&apos;t exist. let&apos;s go home.
+      </Title>
       <Link
         href="/"
         className="text-muted-foreground hover:text-foreground text-sm"


### PR DESCRIPTION
### TL;DR

Added a new post about "uvacompute" and updated personal information in README.md.

### What changed?

- Added a new post entry for "uvacompute" with a CpuIcon in the navigation
- Created a new `uvacompute.md` file with initial content about personal work log
- Updated README.md with current status (now fourth year instead of third year)
- Added sections for "built", "in progress", and "todo" projects in README.md
- Enhanced the 404 page to use the Title component instead of a paragraph

### How to test?

1. Check that the new "uvacompute" post appears in the navigation
2. Verify the updated README.md content displays correctly
3. Test the 404 page to ensure it uses the Title component with proper styling
4. Confirm the visibility settings are correct (uvacompute is set to private)

### Why make this change?

This update reflects my current status as a fourth-year student and showcases my latest projects. The addition of "uvacompute" highlights a new in-progress project that allows users to rent compute from my personal workstation. The improved organization of projects into "built", "in progress", and "todo" categories provides better structure to my portfolio.