### PR TITLE
Update personal interests to focus on math and interpretability

### DIFF
--- a/app/[topic]/[slug]/page.tsx
+++ b/app/[topic]/[slug]/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata({
   const { topic, slug } = await params;
 
   let title = "Charlie Meyer";
-  let description = "infrastructure, ai, llms, and safety.";
+  let description = " ai, llms, math, and interpretability.";
 
   try {
     const post = await getPostData(topic, slug);

--- a/app/_content/posts/readme-md.md
+++ b/app/_content/posts/readme-md.md
@@ -11,7 +11,7 @@ hey, I'm charlie meyer.
 
 I'm a fourth year @ UVA studying computer science and entrepreneurship. I'm a 2025 [Neo Scholar](https://neo.com/scholars), Model UN-er, dedicated weightlifter, and (decent) snowboarder. Previously, I've worked at [Principal Financial](https://www.principal.com/), [Scenthound](https://www.scenthound.com/), and [Vercel](https://vercel.com/).
 
-I work on inference research with [Zhepei Wei](https://weizhepei.com/) and independently explore AI for math research. How can we get LLMs to reason in formal math (Lean)?
+I work on inference speedup research (speculative decoding) with [Zhepei Wei](https://weizhepei.com/) and independently explore AI for math research. How can we get LLMs to reason in formal math (Lean)?
 
 ---
 
@@ -27,6 +27,7 @@ I work on inference research with [Zhepei Wei](https://weizhepei.com/) and indep
 ## todo
 
 - self driving couch
+- re-implement golden gate claude but for the UVA rotunda
 - my own os
 
 ---
@@ -34,7 +35,7 @@ I work on inference research with [Zhepei Wei](https://weizhepei.com/) and indep
 ## future
 
 The intersection of what I'm good at, what I care about, and what's important in the world is AGI and AI safety. So I'm working on that, and
-its subproblems. That currently being inference research, automated theorem proving, and some safety work.
+its subproblems. That currently being inference research, automated theorem proving, and some interpretability work.
 
 I'm also deeply interested in the infrastructure behind AI research. Why is it so hard to run experiments at scale, multi-node, multi-gpu? Training and serving models should be as easy as developing and deploying web apps.
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,9 @@
-import { Subtitle } from '@/components/intuitive-ui/(native)/(typography)/subtitle';
-import { Title } from '@/components/intuitive-ui/(native)/(typography)/title';
+import { Subtitle } from "@/components/intuitive-ui/(native)/(typography)/subtitle";
+import { Title } from "@/components/intuitive-ui/(native)/(typography)/title";
 
-import DashedGridGutter from './_components/dashed-grid-gutter';
-import FilteredTableOfContents from './_components/filtered-table-of-contents';
-import Footer from './_components/footer';
+import DashedGridGutter from "./_components/dashed-grid-gutter";
+import FilteredTableOfContents from "./_components/filtered-table-of-contents";
+import Footer from "./_components/footer";
 
 export default function Home() {
   return (
@@ -11,7 +11,7 @@ export default function Home() {
       <div className="flex flex-col gap-8 p-6 py-24 pb-20 sm:px-16 sm:pb-24">
         <div>
           <Title>charlie meyer</Title>
-          <Subtitle balance>infrastructure, ai, llms, and safety.</Subtitle>
+          <Subtitle balance>ai, llms, math, and interpretability.</Subtitle>
         </div>
         <FilteredTableOfContents />
       </div>


### PR DESCRIPTION
### TL;DR

Updated personal website content to reflect current research focus on AI, math, and interpretability.

### What changed?

- Updated the site description from "infrastructure, ai, llms, and safety" to "ai, llms, math, and interpretability" in both the page metadata and homepage subtitle
- Added specificity to research description, clarifying work on "inference speedup research (speculative decoding)"
- Added a new todo item: "re-implement golden gate claude but for the UVA rotunda"
- Changed reference to "safety work" to "interpretability work" in the future section

### How to test?

1. Visit the homepage and verify the updated subtitle displays correctly
2. Check the metadata description on post pages
3. Review the readme content to ensure research descriptions and todo items appear correctly

### Why make this change?

To better reflect current research interests and focus areas, providing visitors with a more accurate representation of work in AI, math, and interpretability rather than infrastructure and safety.